### PR TITLE
Don't copy attributes if the API doesn't return result

### DIFF
--- a/atws/monkeypatch/crud.py
+++ b/atws/monkeypatch/crud.py
@@ -11,7 +11,8 @@ from . import monkey_patch
 
 def mp_update(entity):
     result = entity._wrapper.update(entity).fetch_one()
-    copy_attributes(result,entity)
+    if result:
+        copy_attributes(result,entity)
     return True
 
 
@@ -24,13 +25,15 @@ def mp_reload(entity):
     query = query.Query(get_entity_type(entity))
     query.WHERE('id',query.Equals,entity.id)
     result = entity._wrapper.query(query).fetch_one()
-    copy_attributes(result,entity)
+    if result:
+        copy_attributes(result,entity)
     return True
     
 
 def mp_create(entity):
     result = entity._wrapper.create(entity).fetch_one()
-    copy_attributes(result,entity)
+    if result:
+        copy_attributes(result,entity)
     return True
     
 generic_patches = {


### PR DESCRIPTION
Not all end-points return an object so a `NoneType` error got raised.

For example the creation of a `ContractServiceAdjustment` doens't return an object.

```
  File "/usr/local/lib/python3.6/site-packages/atws/monkeypatch/crud.py", line 33, in mp_create
    copy_attributes(result,entity)
  File "/usr/local/lib/python3.6/site-packages/atws/helpers.py", line 20, in copy_attributes
    attributes = [field[0] for field in from_entity]
TypeError: 'NoneType' object is not iterable
```
